### PR TITLE
CA-303: job details page performance boost

### DIFF
--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -570,7 +570,8 @@ redis_ondisk_port = os.getenv("CVAT_REDIS_ONDISK_PORT", 6666)
 redis_ondisk_password = os.getenv("CVAT_REDIS_ONDISK_PASSWORD", "")
 
 # Sets the timeout for the expiration of data chunk in redis_ondisk
-CVAT_CHUNK_CACHE_TTL = 3600 * 24  # 1 day
+# Set to7 days (default), configurable via env var. CVAT original default is 1 day.
+CVAT_CHUNK_CACHE_TTL = int(os.getenv("CVAT_CHUNK_CACHE_TTL", 3600 * 24 * 7))
 
 # Sets the timeout for the expiration of preview image in redis_ondisk
 CVAT_PREVIEW_CACHE_TTL = 3600 * 24 * 7  # 7 days

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-backend-env: &backend-env
   CVAT_REDIS_ONDISK_PORT: 6666
   CVAT_LOG_IMPORT_ERRORS: 'true'
   CVAT_ALLOW_STATIC_CACHE: '${CVAT_ALLOW_STATIC_CACHE:-no}'
+  CVAT_CHUNK_CACHE_TTL: '${CVAT_CHUNK_CACHE_TTL:-604800}' # default to 7 days
   DJANGO_LOG_SERVER_HOST: vector
   DJANGO_LOG_SERVER_PORT: 80
   no_proxy: clickhouse,grafana,vector,nuclio,opa,${no_proxy:-}
@@ -53,8 +54,10 @@ services:
     restart: always
     command: [
       "redis-server",
-      "--save", "60", "100",
-      "--appendonly", "yes",
+      "--maxmemory", "8gb", # Limit maximum memory usage to 8 GB
+      "--maxmemory-policy", "allkeys-lru", # Evict any key using Least Recently Used (LRU) when maxmemory is reached
+      "--save", "60", "100", # Snapshot RDB: save the DB every 60 seconds if at least 100 keys changed
+      "--appendonly", "yes", # Enable AOF (Append Only File) persistence for durability
     ]
     volumes:
       - cvat_inmem_db:/data
@@ -77,6 +80,7 @@ services:
       - cvat
     command: [
       "--compact-cron", "0 3 * * *",
+      "--max-db-size", "100GB", # 100GB allows caching ~500-1000 chunks since we change cache TTL to 7 days
       ]
 
   cvat_server:
@@ -93,7 +97,7 @@ services:
       DJANGO_MODWSGI_EXTRA_ARGS: ''
       ALLOWED_HOSTS: '*'
       ADAPTIVE_AUTO_ANNOTATION: 'false'
-      NUMPROCS: 2
+      NUMPROCS: 4
       CVAT_ANALYTICS: 1
       CVAT_BASE_URL:
       ONE_RUNNING_JOB_IN_QUEUE_PER_USER:
@@ -143,7 +147,7 @@ services:
     depends_on: *backend-deps
     environment:
       <<: *backend-env
-      NUMPROCS: 2
+      NUMPROCS: 4
     command: run worker import
     volumes:
       - cvat_data:/home/django/data
@@ -159,7 +163,7 @@ services:
     depends_on: *backend-deps
     environment:
       <<: [*backend-env, *clickhouse-env]
-      NUMPROCS: 2
+      NUMPROCS: 4
     command: run worker export
     volumes:
       - cvat_data:/home/django/data
@@ -175,7 +179,7 @@ services:
     depends_on: *backend-deps
     environment:
       <<: *backend-env
-      NUMPROCS: 1
+      NUMPROCS: 2
     command: run worker annotation
     volumes:
       - cvat_data:/home/django/data
@@ -207,7 +211,7 @@ services:
     depends_on: *backend-deps
     environment:
       <<: *backend-env
-      NUMPROCS: 1
+      NUMPROCS: 2
     command: run worker quality_reports
     volumes:
       - cvat_data:/home/django/data
@@ -223,7 +227,7 @@ services:
     depends_on: *backend-deps
     environment:
       <<: *backend-env
-      NUMPROCS: 2
+      NUMPROCS: 12
     command: run worker chunks
     volumes:
       - cvat_data:/home/django/data


### PR DESCRIPTION
Updated configuration for performance boost:

1. Change redis chunk cache TTL from 1 day to 7 day
2. Optimise redis on disk cache memory size  and invalidation algorithm.
3. Adjust process for better utilisation of memory and CPU cores based on the GCE **e2-highmem-16** (16 vCPUs, 128 GB Memory)

### CPU Allocation (16 vCPUs in total)
- **cvat_server**: 4 processes
- **cvat_worker_chunks**: 12 processes (Critical for job page performance)
- **cvat_worker_import**: 4 processes
- **cvat_worker_export**: 4 processes
- **cvat_worker_annotation**: 2 processes
- **cvat_worker_quality_reports**: 2 processes
- **Other workers**: 1-2 processes each
- **PostgreSQL**: ~2 vCPUs
- **Redis**: ~2 vCPUs
- **System**: ~2 vCPUs

### Assumptions

1. CVat workers are IO bound (DB, GCS read/write)  and assuming a CPU utilisation of 10% ~ 20%. All worker processes will actively consume  about half of the 16 vCPUs.  
2. Effective CPU Cores Needed = (Total Processes × CPU Utilization)

### Deployment steps

1. merge -> CI/CD
2. Monitor for issues
3. Revert if needed.


### Alternatives

Updating the above configurations is the easiest way to get immediate performance improvement requiring no infrastructure update and with minimum risk. The alternative are:

1. Enable static cache in CVAT --- requires migrating old cache to new disk cache
4. Index GCS image data --- requires running index script across all images in the dataset -- not viable.


