### PR TITLE
CA-303: fix redis kvrocks container settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,10 +78,7 @@ services:
       - cvat_cache_db:/var/lib/kvrocks
     networks:
       - cvat
-    command: [
-      "--compact-cron", "0 3 * * *",
-      "--max-db-size", "100GB", # 100GB allows caching ~500-1000 chunks since we change cache TTL to 7 days
-      ]
+    command: [ "--compact-cron", "0 3 * * *" ]
 
   cvat_server:
     container_name: cvat_server


### PR DESCRIPTION
CA-303: fix redis kvrocks container settings

- "100GB" is invalid syntax ( need to use numeric byte count string)
- This PR remove the max memory settings as we have enough disk space  (400GB)