### PR TITLE
CA-324: fix job details page image setup trigger and layer slider invisible

### DIFF
--- a/cvat-ui/src/components/annotation-page/styles.scss
+++ b/cvat-ui/src/components/annotation-page/styles.scss
@@ -356,7 +356,7 @@
 .cvat-canvas-image-setups-trigger {
     position: absolute;
     background: $background-color-2;
-    bottom: 0;
+    bottom: 20px;
     left: 50%;
     opacity: 0.5;
     border-radius: $border-radius-base $border-radius-base 0 0;
@@ -427,7 +427,7 @@
 .cvat-canvas-z-axis-wrapper {
     position: absolute;
     background: $background-color-2;
-    bottom: 10px;
+    bottom: 30px;
     right: 10px;
     height: 150px;
     z-index: 100;


### PR DESCRIPTION
This PR adjust the position of the image settings popover trigger and layer slider control so that they are remain visible after the introduction of the job Breadcrumbs control before.
<img width="933" height="937" alt="image" src="https://github.com/user-attachments/assets/75499377-2723-4faa-8ce5-0c88d2cefa9e" />

