### PR TITLE
CA-325: add img settings toggle

### DIFF
--- a/cvat-ui/src/actions/settings-actions.ts
+++ b/cvat-ui/src/actions/settings-actions.ts
@@ -59,6 +59,7 @@ export enum SettingsActionTypes {
     DISABLE_IMAGE_FILTER = 'DISABLE_IMAGE_FILTER',
     RESET_IMAGE_FILTERS = 'RESET_IMAGE_FILTERS',
     CHANGE_SHAPES_ORIENTATION_VISIBILITY = 'CHANGE_SHAPES_ORIENTATION_VISIBILITY',
+    SWITCH_IMAGE_FILTERS_ENABLED = 'SWITCH_IMAGE_FILTERS_ENABLED',
 }
 
 export function changeShapesOpacity(opacity: number): AnyAction {
@@ -434,6 +435,15 @@ export function resetImageFilters(): AnyAction {
     return {
         type: SettingsActionTypes.RESET_IMAGE_FILTERS,
         payload: {},
+    };
+}
+
+export function switchImageFiltersEnabled(enabled: boolean): AnyAction {
+    return {
+        type: SettingsActionTypes.SWITCH_IMAGE_FILTERS_ENABLED,
+        payload: {
+            enabled,
+        },
     };
 }
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/__tests__/image-setups-content.test.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/__tests__/image-setups-content.test.tsx
@@ -1,0 +1,221 @@
+// Copyright (C) CoTreat Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { GridColor, FrameSpeed } from 'reducers';
+
+// Mock react-redux
+const mockDispatch = jest.fn();
+let mockSelectorState = {
+    brightnessLevel: 100,
+    contrastLevel: 100,
+    saturationLevel: 100,
+    gridOpacity: 100,
+    gridColor: GridColor.White,
+    gridSize: 100,
+    grid: false,
+    imageFiltersEnabled: true,
+};
+
+jest.mock('react-redux', () => ({
+    useDispatch: () => mockDispatch,
+    useSelector: (selector: any) => {
+        // Return the player settings directly
+        return mockSelectorState;
+    },
+}));
+
+// Mock GammaFilter component
+jest.mock('../gamma-filter', () => function MockGammaFilter({ disabled }: { disabled?: boolean }) {
+    return <div data-testid="gamma-filter" data-disabled={disabled}>Gamma Filter</div>;
+});
+
+// Mock actions
+jest.mock('actions/settings-actions', () => ({
+    switchGrid: jest.fn((value) => ({ type: 'SWITCH_GRID', payload: { grid: value } })),
+    changeGridColor: jest.fn((value) => ({ type: 'CHANGE_GRID_COLOR', payload: { gridColor: value } })),
+    changeGridOpacity: jest.fn((value) => ({ type: 'CHANGE_GRID_OPACITY', payload: { gridOpacity: value } })),
+    changeBrightnessLevel: jest.fn((value) => ({ type: 'CHANGE_BRIGHTNESS_LEVEL', payload: { level: value } })),
+    changeContrastLevel: jest.fn((value) => ({ type: 'CHANGE_CONTRAST_LEVEL', payload: { level: value } })),
+    changeSaturationLevel: jest.fn((value) => ({ type: 'CHANGE_SATURATION_LEVEL', payload: { level: value } })),
+    changeGridSize: jest.fn((value) => ({ type: 'CHANGE_GRID_SIZE', payload: { gridSize: value } })),
+    resetImageFilters: jest.fn(() => ({ type: 'RESET_IMAGE_FILTERS', payload: {} })),
+    switchImageFiltersEnabled: jest.fn((value) => ({ type: 'SWITCH_IMAGE_FILTERS_ENABLED', payload: { enabled: value } })),
+}));
+
+// Mock utils/math
+jest.mock('utils/math', () => ({
+    clamp: (value: number, min: number, max: number) => Math.min(Math.max(value, min), max),
+}));
+
+// Import component after mocks
+import ImageSetupsContent from '../image-setups-content';
+import { switchImageFiltersEnabled, changeBrightnessLevel, changeContrastLevel, changeSaturationLevel, resetImageFilters } from 'actions/settings-actions';
+
+describe('ImageSetupsContent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Reset to default state
+        mockSelectorState = {
+            brightnessLevel: 100,
+            contrastLevel: 100,
+            saturationLevel: 100,
+            gridOpacity: 100,
+            gridColor: GridColor.White,
+            gridSize: 100,
+            grid: false,
+            imageFiltersEnabled: true,
+        };
+    });
+
+    describe('Image Filters Toggle', () => {
+        it('should render the color settings section with enabled checkbox', () => {
+            render(<ImageSetupsContent />);
+
+            expect(screen.getByText('Color settings')).toBeInTheDocument();
+            expect(screen.getByText('Enabled')).toBeInTheDocument();
+        });
+
+        it('should display keyboard shortcut tag next to enabled checkbox', () => {
+            const { container } = render(<ImageSetupsContent />);
+
+            const shortcutTag = container.querySelector('.cvat-image-setups-shortcut-tag');
+            expect(shortcutTag).toBeInTheDocument();
+            expect(shortcutTag).toHaveTextContent('I');
+        });
+
+        it('should have checkbox checked when imageFiltersEnabled is true', () => {
+            mockSelectorState.imageFiltersEnabled = true;
+
+            const { container } = render(<ImageSetupsContent />);
+
+            // Find the checkbox by class name
+            const checkbox = container.querySelector('.cvat-image-setups-filters-enable-checkbox input[type="checkbox"]');
+            expect(checkbox).toBeChecked();
+        });
+
+        it('should have checkbox unchecked when imageFiltersEnabled is false', () => {
+            mockSelectorState.imageFiltersEnabled = false;
+
+            const { container } = render(<ImageSetupsContent />);
+
+            // Find the checkbox by class name
+            const checkbox = container.querySelector('.cvat-image-setups-filters-enable-checkbox input[type="checkbox"]');
+            expect(checkbox).not.toBeChecked();
+        });
+
+        it('should dispatch switchImageFiltersEnabled(false) when checkbox is unchecked', () => {
+            mockSelectorState.imageFiltersEnabled = true;
+
+            const { container } = render(<ImageSetupsContent />);
+
+            // Find and click the checkbox
+            const checkbox = container.querySelector('.cvat-image-setups-filters-enable-checkbox input[type="checkbox"]');
+            fireEvent.click(checkbox!);
+
+            expect(switchImageFiltersEnabled).toHaveBeenCalledWith(false);
+            expect(mockDispatch).toHaveBeenCalled();
+        });
+
+        it('should dispatch switchImageFiltersEnabled(true) when checkbox is checked', () => {
+            mockSelectorState.imageFiltersEnabled = false;
+
+            const { container } = render(<ImageSetupsContent />);
+
+            // Find and click the checkbox
+            const checkbox = container.querySelector('.cvat-image-setups-filters-enable-checkbox input[type="checkbox"]');
+            fireEvent.click(checkbox!);
+
+            expect(switchImageFiltersEnabled).toHaveBeenCalledWith(true);
+            expect(mockDispatch).toHaveBeenCalled();
+        });
+
+        it('should pass disabled=false to GammaFilter when imageFiltersEnabled is true', () => {
+            mockSelectorState.imageFiltersEnabled = true;
+
+            render(<ImageSetupsContent />);
+
+            const gammaFilter = screen.getByTestId('gamma-filter');
+            expect(gammaFilter).toHaveAttribute('data-disabled', 'false');
+        });
+
+        it('should pass disabled=true to GammaFilter when imageFiltersEnabled is false', () => {
+            mockSelectorState.imageFiltersEnabled = false;
+
+            render(<ImageSetupsContent />);
+
+            const gammaFilter = screen.getByTestId('gamma-filter');
+            expect(gammaFilter).toHaveAttribute('data-disabled', 'true');
+        });
+    });
+
+    describe('Color Settings Controls', () => {
+        it('should render brightness, contrast, and saturation controls', () => {
+            render(<ImageSetupsContent />);
+
+            expect(screen.getByText('Brightness')).toBeInTheDocument();
+            expect(screen.getByText('Contrast')).toBeInTheDocument();
+            expect(screen.getByText('Saturation')).toBeInTheDocument();
+        });
+
+        it('should render the gamma filter component', () => {
+            render(<ImageSetupsContent />);
+
+            expect(screen.getByTestId('gamma-filter')).toBeInTheDocument();
+        });
+
+        it('should render the reset button', () => {
+            render(<ImageSetupsContent />);
+
+            expect(screen.getByText('Reset color settings')).toBeInTheDocument();
+        });
+
+        it('should dispatch reset actions when reset button is clicked', () => {
+            render(<ImageSetupsContent />);
+
+            const resetButton = screen.getByText('Reset color settings');
+            fireEvent.click(resetButton);
+
+            expect(changeBrightnessLevel).toHaveBeenCalledWith(100);
+            expect(changeContrastLevel).toHaveBeenCalledWith(100);
+            expect(changeSaturationLevel).toHaveBeenCalledWith(100);
+            expect(resetImageFilters).toHaveBeenCalled();
+        });
+    });
+
+    describe('Image Grid Controls', () => {
+        it('should render image grid section', () => {
+            render(<ImageSetupsContent />);
+
+            expect(screen.getByText('Image grid')).toBeInTheDocument();
+            expect(screen.getByText('Size')).toBeInTheDocument();
+            expect(screen.getByText('Color')).toBeInTheDocument();
+            expect(screen.getByText('Opacity')).toBeInTheDocument();
+        });
+    });
+});
+
+/**
+ * Tests for the image filters enabled state logic
+ */
+describe('ImageFiltersEnabled State Logic', () => {
+    it('should default to enabled (true)', () => {
+        // The default state in the reducer should be true
+        const defaultValue = true;
+        expect(defaultValue).toBe(true);
+    });
+
+    it('action payload should contain correct enabled value when toggling off', () => {
+        const action = { type: 'SWITCH_IMAGE_FILTERS_ENABLED', payload: { enabled: false } };
+        expect(action.payload.enabled).toBe(false);
+    });
+
+    it('action payload should contain correct enabled value when toggling on', () => {
+        const action = { type: 'SWITCH_IMAGE_FILTERS_ENABLED', payload: { enabled: true } };
+        expect(action.payload.enabled).toBe(true);
+    });
+});

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
@@ -55,6 +55,7 @@ import {
     changeContrastLevel,
     changeSaturationLevel,
     switchAutomaticBordering,
+    switchImageFiltersEnabled,
 } from 'actions/settings-actions';
 import { reviewActions } from 'actions/review-actions';
 
@@ -119,6 +120,7 @@ interface StateToProps {
     showGroundTruth: boolean;
     highlightedConflict: QualityConflict | null;
     imageFilters: ImageFilter[];
+    imageFiltersEnabled: boolean;
     activeControl: ActiveControl;
     activeObjectHidden: boolean;
 }
@@ -149,6 +151,7 @@ interface DispatchToProps {
     onCanvasErrorOccurred(error: Error): void;
     onStartIssue(position: number[]): void;
     onUpdateEditedObject(editedState: ObjectState | null): void;
+    onSwitchImageFiltersEnabled(enabled: boolean): void;
 }
 
 function mapStateToProps(state: CombinedState): StateToProps {
@@ -184,6 +187,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
                 saturationLevel,
                 resetZoom,
                 smoothImage,
+                imageFiltersEnabled,
             },
             workspace: {
                 aamZoomMargin,
@@ -262,6 +266,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
         showGroundTruth,
         highlightedConflict,
         imageFilters,
+        imageFiltersEnabled,
         activeObjectHidden,
     };
 }
@@ -271,6 +276,12 @@ const componentShortcuts = {
         name: 'Switch automatic bordering',
         description: 'Switch automatic bordering for polygons and polylines during drawing/editing',
         sequences: ['ctrl+a'],
+        scope: ShortcutScope.STANDARD_WORKSPACE,
+    },
+    TOGGLE_IMAGE_FILTERS: {
+        name: 'Toggle image color settings',
+        description: 'Enable/disable image color settings (brightness, contrast, saturation, gamma)',
+        sequences: ['i'],
         scope: ShortcutScope.STANDARD_WORKSPACE,
     },
 };
@@ -357,6 +368,9 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
         },
         onUpdateEditedObject(editedState: ObjectState | null): void {
             dispatch(updateEditedStateAsync(editedState));
+        },
+        onSwitchImageFiltersEnabled(enabled: boolean): void {
+            dispatch(switchImageFiltersEnabled(enabled));
         },
     };
 }
@@ -457,6 +471,7 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             showGroundTruth,
             highlightedConflict,
             imageFilters,
+            imageFiltersEnabled,
         } = this.props;
         const { canvasInstance } = this.props as { canvasInstance: Canvas };
 
@@ -545,15 +560,22 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
         if (
             brightnessLevel !== prevProps.brightnessLevel ||
             contrastLevel !== prevProps.contrastLevel ||
-            saturationLevel !== prevProps.saturationLevel
+            saturationLevel !== prevProps.saturationLevel ||
+            imageFiltersEnabled !== prevProps.imageFiltersEnabled
         ) {
-            canvasInstance.configure({
-                CSSImageFilter:
-                    `brightness(${brightnessLevel}) contrast(${contrastLevel}) saturate(${saturationLevel})`,
-            });
+            if (imageFiltersEnabled) {
+                canvasInstance.configure({
+                    CSSImageFilter:
+                        `brightness(${brightnessLevel}) contrast(${contrastLevel}) saturate(${saturationLevel})`,
+                });
+            } else {
+                canvasInstance.configure({
+                    CSSImageFilter: 'none',
+                });
+            }
         }
 
-        if (prevProps.imageFilters !== imageFilters) {
+        if (prevProps.imageFilters !== imageFilters || imageFiltersEnabled !== prevProps.imageFiltersEnabled) {
             canvasInstance.configure({ forceFrameUpdate: true });
         }
 
@@ -963,7 +985,7 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
     private updateCanvas(): void {
         const {
             curZLayer, annotations, frameData,
-            workspace, frame, imageFilters,
+            workspace, frame, imageFilters, imageFiltersEnabled,
         } = this.props;
 
         const { canvasInstance } = this.props as { canvasInstance: Canvas };
@@ -978,9 +1000,11 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
                     if (prop === 'data') {
                         return async (...args: any[]) => {
                             const originalImage = await _frameData.data(...args);
-                            const imageIsNotProcessed = imageFilters.some((imageFilter: ImageFilter) => (
-                                imageFilter.modifier.currentProcessedImage !== frame
-                            ));
+                            const imageIsNotProcessed = imageFiltersEnabled && imageFilters.some(
+                                (imageFilter: ImageFilter) => (
+                                    imageFilter.modifier.currentProcessedImage !== frame
+                                ),
+                            );
 
                             if (imageIsNotProcessed) {
                                 try {
@@ -1033,6 +1057,7 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             brightnessLevel,
             contrastLevel,
             saturationLevel,
+            imageFiltersEnabled,
         } = this.props;
         const { canvasInstance } = this.props as { canvasInstance: Canvas };
 
@@ -1049,8 +1074,9 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
         canvasInstance.grid(gridSize, gridSize);
 
         canvasInstance.configure({
-            CSSImageFilter:
-                `brightness(${brightnessLevel}) contrast(${contrastLevel}) saturate(${saturationLevel})`,
+            CSSImageFilter: imageFiltersEnabled ?
+                `brightness(${brightnessLevel}) contrast(${contrastLevel}) saturate(${saturationLevel})` :
+                'none',
         });
 
         canvasInstance.fitCanvas();
@@ -1105,9 +1131,11 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             automaticBordering,
             showTagsOnFrame,
             canvasIsReady,
+            imageFiltersEnabled,
             onSwitchAutomaticBordering,
             onSwitchZLayer,
             onAddZLayer,
+            onSwitchImageFiltersEnabled,
         } = this.props;
 
         const preventDefault = (event: KeyboardEvent | undefined): void => {
@@ -1122,6 +1150,10 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
                     preventDefault(event);
                     onSwitchAutomaticBordering(!automaticBordering);
                 }
+            },
+            TOGGLE_IMAGE_FILTERS: (event: KeyboardEvent | undefined) => {
+                preventDefault(event);
+                onSwitchImageFiltersEnabled(!imageFiltersEnabled);
             },
         };
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/gamma-filter.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/gamma-filter.tsx
@@ -16,7 +16,11 @@ import {
 import GammaCorrection from 'utils/fabric-wrapper/gamma-correciton';
 import { ImageFilterAlias, hasFilter } from 'utils/image-processing';
 
-export default function GammaFilter(): JSX.Element {
+interface Props {
+    disabled?: boolean;
+}
+
+export default function GammaFilter({ disabled }: Props): JSX.Element {
     const dispatch = useDispatch();
     const [gamma, setGamma] = useState<number>(1);
     const filters = useSelector((state: CombinedState) => state.settings.imageFilters);
@@ -63,6 +67,7 @@ export default function GammaFilter(): JSX.Element {
                                 max={2.6}
                                 value={gamma}
                                 step={0.01}
+                                disabled={disabled}
                                 onChange={onChangeGamma}
                             />
                         </Col>

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/image-setups-content.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/image-setups-content.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Row, Col } from 'antd/lib/grid';
 import Checkbox, { CheckboxChangeEvent } from 'antd/lib/checkbox';
+import Tag from 'antd/lib/tag';
 import Text from 'antd/lib/typography/Text';
 import InputNumber from 'antd/lib/input-number';
 import Select from 'antd/lib/select';
@@ -22,6 +23,7 @@ import {
     changeSaturationLevel,
     changeGridSize,
     resetImageFilters,
+    switchImageFiltersEnabled,
 } from 'actions/settings-actions';
 import { clamp } from 'utils/math';
 import { GridColor, CombinedState, PlayerSettingsState } from 'reducers';
@@ -40,6 +42,7 @@ export default function ImageSetupsContent(): JSX.Element {
         gridColor,
         gridSize,
         grid: gridEnabled,
+        imageFiltersEnabled,
     } = useSelector((state: CombinedState): PlayerSettingsState => state.settings.player);
 
     return (
@@ -122,7 +125,23 @@ export default function ImageSetupsContent(): JSX.Element {
                     />
                 </Col>
             </Row>
-            <Text>Color settings</Text>
+            <Row justify='space-between' align='middle' className='cvat-image-setups-filters-enable'>
+                <Col>
+                    <Text>Color settings</Text>
+                </Col>
+                <Col>
+                    <Checkbox
+                        className='cvat-image-setups-filters-enable-checkbox'
+                        checked={imageFiltersEnabled}
+                        onChange={(event: CheckboxChangeEvent): void => {
+                            dispatch(switchImageFiltersEnabled(event.target.checked));
+                        }}
+                    >
+                        <Text className='cvat-text-color'>Enabled</Text>
+                    </Checkbox>
+                    <Tag className='cvat-image-setups-shortcut-tag'>I</Tag>
+                </Col>
+            </Row>
             <hr />
             <Row justify='space-around'>
                 <Col span={24}>
@@ -135,6 +154,7 @@ export default function ImageSetupsContent(): JSX.Element {
                                 min={50}
                                 max={200}
                                 value={brightnessLevel}
+                                disabled={!imageFiltersEnabled}
                                 onChange={(value: number | [number, number]): void => {
                                     dispatch(changeBrightnessLevel(value as number));
                                 }}
@@ -150,6 +170,7 @@ export default function ImageSetupsContent(): JSX.Element {
                                 min={50}
                                 max={200}
                                 value={contrastLevel}
+                                disabled={!imageFiltersEnabled}
                                 onChange={(value: number | [number, number]): void => {
                                     dispatch(changeContrastLevel(value as number));
                                 }}
@@ -165,6 +186,7 @@ export default function ImageSetupsContent(): JSX.Element {
                                 min={0}
                                 max={300}
                                 value={saturationLevel}
+                                disabled={!imageFiltersEnabled}
                                 onChange={(value: number | [number, number]): void => {
                                     dispatch(changeSaturationLevel(value as number));
                                 }}
@@ -173,7 +195,7 @@ export default function ImageSetupsContent(): JSX.Element {
                     </Row>
                 </Col>
             </Row>
-            <GammaFilter />
+            <GammaFilter disabled={!imageFiltersEnabled} />
             <Row className='cvat-image-setups-reset-color-settings' justify='space-around'>
                 <Col>
                     <Button

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/styles.scss
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/styles.scss
@@ -8,6 +8,16 @@
     margin-bottom: $grid-unit-size * 3;
 }
 
+.cvat-image-setups-shortcut-tag {
+    margin-left: $grid-unit-size;
+    font-family: $monospaced-fonts-stack;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 0 $grid-unit-size;
+    line-height: 18px;
+    border-radius: $border-radius-base;
+}
+
 .cvat-canvas-hints-container {
     filter: none;
     position: absolute;

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -896,6 +896,7 @@ export interface PlayerSettingsState {
     brightnessLevel: number;
     contrastLevel: number;
     saturationLevel: number;
+    imageFiltersEnabled: boolean;
 }
 
 export interface WorkspaceSettingsState {

--- a/cvat-ui/src/reducers/settings-reducer.ts
+++ b/cvat-ui/src/reducers/settings-reducer.ts
@@ -63,6 +63,7 @@ const defaultState: SettingsState = {
         brightnessLevel: 100,
         contrastLevel: 100,
         saturationLevel: 100,
+        imageFiltersEnabled: true,
     },
     imageFilters: [],
     showDialog: false,
@@ -461,6 +462,15 @@ export default (state = defaultState, action: AnyAction): SettingsState => {
             return {
                 ...state,
                 imageFilters: [],
+            };
+        }
+        case SettingsActionTypes.SWITCH_IMAGE_FILTERS_ENABLED: {
+            return {
+                ...state,
+                player: {
+                    ...state.player,
+                    imageFiltersEnabled: action.payload.enabled,
+                },
             };
         }
         case AnnotationActionTypes.GET_JOB_SUCCESS: {


### PR DESCRIPTION

Add an image settings toggle to disable/enable global image settings. 

- Allow temporary on/off switch for image settings (contrast, brightness etc)
- Use keyboard shortcut 'I' to quickly enable/disable image settings

<img width="774" height="589" alt="image" src="https://github.com/user-attachments/assets/7851f5b2-3a70-42eb-baa7-678136bfff0f" />
