### PR TITLE
CA-333: Show project descriptions on project page

### DIFF
--- a/cvat-ui/src/components/annotation-page/styles.scss
+++ b/cvat-ui/src/components/annotation-page/styles.scss
@@ -17,7 +17,7 @@
 
 .cvat-annotation-breadcrumb {
     background-color: $background-color-1;
-    padding: $grid-unit-size $grid-unit-size * 2 $grid-unit-size / 2;
+    padding: $grid-unit-size $grid-unit-size * 2 calc($grid-unit-size / 2);
 
     .cvat-job-breadcrumb-history-button {
         cursor: pointer;

--- a/cvat-ui/src/components/md-guide/__tests__/md-guide-control.test.tsx
+++ b/cvat-ui/src/components/md-guide/__tests__/md-guide-control.test.tsx
@@ -1,0 +1,295 @@
+// Copyright (C) CoTreat Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock react-router
+const mockHistoryPush = jest.fn();
+jest.mock('react-router', () => ({
+    useHistory: () => ({
+        push: mockHistoryPush,
+    }),
+}));
+
+// Mock cvat-core-wrapper
+jest.mock('cvat-core-wrapper', () => ({
+    AnnotationGuide: jest.fn(),
+    Project: jest.fn(),
+    Task: jest.fn(),
+}));
+
+// Mock MDEditor
+jest.mock('@uiw/react-md-editor', () => ({
+    __esModule: true,
+    default: {
+        Markdown: ({ source }: { source: string }) => (
+            <div data-testid="markdown-content">{source}</div>
+        ),
+    },
+}));
+
+// Mock @ant-design/icons
+jest.mock('@ant-design/icons', () => ({
+    EditOutlined: (props: any) => (
+        <span
+            data-testid="edit-icon"
+            className={props.className}
+            onClick={props.onClick}
+        >
+            EditIcon
+        </span>
+    ),
+}));
+
+// Mock styles
+jest.mock('../styles.scss', () => ({}));
+
+import MdGuideControl from '../md-guide-control';
+
+describe('MdGuideControl', () => {
+    const mockGuide = jest.fn();
+
+    const createMockInstance = (markdown: string | null = null) => ({
+        guide: mockGuide.mockResolvedValue(
+            markdown ? { markdown } : null,
+        ),
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render the title for project type', async () => {
+        const mockInstance = createMockInstance(null);
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        expect(screen.getByText('Project description')).toBeInTheDocument();
+    });
+
+    it('should render the title for task type', async () => {
+        const mockInstance = createMockInstance(null);
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="task"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        expect(screen.getByText('Task description')).toBeInTheDocument();
+    });
+
+    it('should display "No description available" when guide is null', async () => {
+        const mockInstance = createMockInstance(null);
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('No description available')).toBeInTheDocument();
+        });
+    });
+
+    it('should display markdown content when guide exists', async () => {
+        const mockInstance = createMockInstance('# Test Description\n\nThis is a test.');
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('markdown-content')).toHaveTextContent('# Test Description');
+        });
+    });
+
+    it('should navigate to edit page when edit icon is clicked', async () => {
+        const mockInstance = createMockInstance(null);
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={123}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        const editIcon = screen.getByTestId('edit-icon');
+        expect(editIcon).toBeInTheDocument();
+
+        await act(async () => {
+            fireEvent.click(editIcon);
+        });
+
+        expect(mockHistoryPush).toHaveBeenCalledWith('/projects/123/guide');
+    });
+
+    it('should navigate to task edit page for task type', async () => {
+        const mockInstance = createMockInstance(null);
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="task"
+                    id={456}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        const editIcon = screen.getByTestId('edit-icon');
+
+        await act(async () => {
+            fireEvent.click(editIcon);
+        });
+
+        expect(mockHistoryPush).toHaveBeenCalledWith('/tasks/456/guide');
+    });
+
+    it('should fetch guide on mount', async () => {
+        const mockInstance = createMockInstance('Some content');
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        expect(mockGuide).toHaveBeenCalled();
+    });
+
+    it('should handle guide fetch error gracefully', async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const mockInstance = {
+            guide: jest.fn().mockRejectedValue(new Error('Failed to fetch')),
+        };
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        await waitFor(() => {
+            expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch guide:', expect.any(Error));
+        });
+
+        consoleSpy.mockRestore();
+    });
+
+    it('should show content wrapper with correct class when collapsed', async () => {
+        const mockInstance = createMockInstance('Some content');
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        await waitFor(() => {
+            const contentDiv = document.querySelector('.cvat-md-guide-content');
+            expect(contentDiv).toHaveClass('cvat-md-guide-content-collapsed');
+        });
+    });
+
+    it('should toggle expanded state when "Read more" is clicked', async () => {
+        const longContent = 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8';
+        const mockInstance = createMockInstance(longContent);
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        // Simulate overflow by mocking the ref
+        await waitFor(() => {
+            expect(screen.getByTestId('markdown-content')).toBeInTheDocument();
+        });
+
+        // Note: In a real test environment, we would need to mock scrollHeight/clientHeight
+        // to properly test the overflow detection. This test verifies the basic rendering.
+    });
+
+    it('should render edit icon with correct class', async () => {
+        const mockInstance = createMockInstance(null);
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        const editIcon = screen.getByTestId('edit-icon');
+        expect(editIcon).toBeInTheDocument();
+        expect(editIcon).toHaveClass('cvat-md-guide-edit-icon');
+    });
+
+    it('should render content wrapper with correct class', async () => {
+        const mockInstance = createMockInstance('Test content');
+
+        await act(async () => {
+            render(
+                <MdGuideControl
+                    instanceType="project"
+                    id={1}
+                    instance={mockInstance as any}
+                />,
+            );
+        });
+
+        await waitFor(() => {
+            const wrapper = document.querySelector('.cvat-md-guide-content-wrapper');
+            expect(wrapper).toBeInTheDocument();
+        });
+    });
+});

--- a/cvat-ui/src/components/md-guide/annotation-guide-page.tsx
+++ b/cvat-ui/src/components/md-guide/annotation-guide-page.tsx
@@ -7,7 +7,7 @@ import './styles.scss';
 import React, {
     useState, useEffect, useRef, useCallback,
 } from 'react';
-import { useLocation, useParams } from 'react-router';
+import { useLocation, useParams, useHistory } from 'react-router';
 import { Row, Col } from 'antd/lib/grid';
 import notification from 'antd/lib/notification';
 import Button from 'antd/lib/button';
@@ -24,6 +24,7 @@ const core = getCore();
 function AnnotationGuidePage(): JSX.Element {
     const mdEditorRef = useRef<typeof MDEditor & { commandOrchestrator: commands.TextAreaCommandOrchestrator }>(null);
     const location = useLocation();
+    const history = useHistory();
     const [value, setValue] = useState('');
     const instanceType = location.pathname.includes('projects') ? 'project' : 'task';
     const id = +useParams<{ id: string }>().id;
@@ -56,13 +57,19 @@ function AnnotationGuidePage(): JSX.Element {
             });
     }, []);
 
-    const submit = useCallback((updatedValue: string) => {
+    const submit = useCallback((updatedValue: string, redirect = false) => {
         if (guide) {
             guide.markdown = updatedValue;
             setFetching(true);
             guide.save().then((result: AnnotationGuide) => {
                 setValue(result.markdown);
                 setGuide(result);
+                if (redirect) {
+                    notification.success({
+                        message: 'Description saved successfully',
+                    });
+                    history.push(`/${instanceType}s/${id}`);
+                }
             }).catch((error: unknown) => {
                 notification.error({
                     message: 'Could not save guide on the server',
@@ -72,7 +79,7 @@ function AnnotationGuidePage(): JSX.Element {
                 setFetching(false);
             });
         }
-    }, [guide]);
+    }, [guide, history, instanceType, id]);
 
     const handleInsertFiles = useCallback(async (files: FileList): Promise<void> => {
         if (mdEditorRef.current && guide?.id) {
@@ -171,7 +178,7 @@ function AnnotationGuidePage(): JSX.Element {
                     <Button
                         type='primary'
                         disabled={fetching || !guide?.id}
-                        onClick={() => submit(value)}
+                        onClick={() => submit(value, true)}
                     >
                         Submit
                     </Button>

--- a/cvat-ui/src/components/md-guide/md-guide-control.tsx
+++ b/cvat-ui/src/components/md-guide/md-guide-control.tsx
@@ -4,33 +4,96 @@
 
 import './styles.scss';
 
-import React from 'react';
+import React, {
+    useState, useEffect, useRef, useCallback,
+} from 'react';
 import { useHistory } from 'react-router';
 import { Row, Col } from 'antd/lib/grid';
 import Text from 'antd/lib/typography/Text';
 import Button from 'antd/lib/button';
+import { EditOutlined } from '@ant-design/icons';
+import MDEditor from '@uiw/react-md-editor';
+
+import { AnnotationGuide, Project, Task } from 'cvat-core-wrapper';
 
 interface Props {
     instanceType: 'task' | 'project';
     id: number;
+    instance: Project | Task;
 }
 
 function MdGuideControl(props: Props): JSX.Element {
-    const { instanceType, id } = props;
+    const { instanceType, id, instance } = props;
     const history = useHistory();
+    const [description, setDescription] = useState<string | null>(null);
+    const [expanded, setExpanded] = useState(false);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+    const contentRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        instance.guide()
+            .then((existingGuide: AnnotationGuide | null) => {
+                if (existingGuide) {
+                    setDescription(existingGuide.markdown);
+                }
+            }).catch((error: unknown) => {
+                // eslint-disable-next-line no-console
+                console.error('Failed to fetch guide:', error);
+            });
+    }, [instance]);
+
+    const checkOverflow = useCallback(() => {
+        if (contentRef.current) {
+            const { scrollHeight, clientHeight } = contentRef.current;
+            setIsOverflowing(scrollHeight > clientHeight);
+        }
+    }, []);
+
+    useEffect(() => {
+        checkOverflow();
+        window.addEventListener('resize', checkOverflow);
+        return () => window.removeEventListener('resize', checkOverflow);
+    }, [description, checkOverflow]);
+
+    const title = `${instanceType[0].toUpperCase()}${instanceType.slice(1)} description`;
 
     return (
         <Row justify='start' className='cvat-md-guide-control-wrapper'>
             <Col span={24}>
-                <Text strong className='cvat-text-color'>{`${instanceType[0].toUpperCase()}${instanceType.slice(1)} description`}</Text>
-                <br />
-                <Button
-                    onClick={() => {
-                        history.push(`/${instanceType}s/${id}/guide`);
-                    }}
-                >
-                    Edit
-                </Button>
+                <div className='cvat-md-guide-header'>
+                    <Text strong className='cvat-text-color'>{title}</Text>
+                    <EditOutlined
+                        className='cvat-md-guide-edit-icon'
+                        onClick={() => {
+                            history.push(`/${instanceType}s/${id}/guide`);
+                        }}
+                    />
+                </div>
+                {description ? (
+                    <div className='cvat-md-guide-content-wrapper'>
+                        <div
+                            ref={contentRef}
+                            className={`cvat-md-guide-content ${expanded ? 'cvat-md-guide-content-expanded' : 'cvat-md-guide-content-collapsed'}`}
+                            data-color-mode='light'
+                        >
+                            <MDEditor.Markdown source={description} />
+                        </div>
+                        {!expanded && isOverflowing && <div className='cvat-md-guide-content-fade' />}
+                        {isOverflowing && (
+                            <Button
+                                type='link'
+                                className='cvat-md-guide-expand-button'
+                                onClick={() => setExpanded(!expanded)}
+                            >
+                                {expanded ? 'Show less' : 'Read more'}
+                            </Button>
+                        )}
+                    </div>
+                ) : (
+                    <div className='cvat-md-guide-content-wrapper'>
+                        <Text type='secondary'>No description available</Text>
+                    </div>
+                )}
             </Col>
         </Row>
     );

--- a/cvat-ui/src/components/md-guide/styles.scss
+++ b/cvat-ui/src/components/md-guide/styles.scss
@@ -7,8 +7,62 @@
 .cvat-md-guide-control-wrapper {
     margin-top: $grid-unit-size;
 
-    button {
-        margin-top: $grid-unit-size;
+    .cvat-md-guide-header {
+        display: flex;
+        align-items: center;
+        margin-bottom: $grid-unit-size;
+
+        .cvat-md-guide-edit-icon {
+            margin-left: $grid-unit-size;
+            color: #1677ff;
+            cursor: pointer;
+
+            &:hover {
+                color: #4096ff;
+            }
+        }
+    }
+
+    .cvat-md-guide-content-wrapper {
+        position: relative;
+        width: 100%;
+        background-color: rgba(0, 0, 0, 3%);
+        border-radius: $border-radius-base;
+        padding: $grid-unit-size * 2;
+
+        .cvat-md-guide-content {
+            overflow: hidden;
+            font-size: 14px;
+
+            &.cvat-md-guide-content-collapsed {
+                max-height: 7.5em; // approximately 5 lines
+            }
+
+            &.cvat-md-guide-content-expanded {
+                max-height: none;
+            }
+
+            .wmde-markdown {
+                background-color: transparent;
+                font-size: inherit;
+            }
+        }
+
+        .cvat-md-guide-content-fade {
+            position: absolute;
+            bottom: $grid-unit-size * 5;
+            left: 0;
+            right: 0;
+            height: 3em;
+            background: linear-gradient(transparent, #f8f8f8);
+            pointer-events: none;
+        }
+
+        .cvat-md-guide-expand-button {
+            padding: 0;
+            height: auto;
+            margin-top: $grid-unit-size;
+        }
     }
 }
 

--- a/cvat-ui/src/components/project-page/details.tsx
+++ b/cvat-ui/src/components/project-page/details.tsx
@@ -28,7 +28,7 @@ export default function DetailsComponent(props: DetailsComponentProps): JSX.Elem
 
     return (
         <div data-cvat-project-id={project.id} className='cvat-project-details'>
-            <Row>
+            <Row justify='space-between' align='middle'>
                 <Col>
                     <Title
                         level={4}
@@ -44,29 +44,29 @@ export default function DetailsComponent(props: DetailsComponentProps): JSX.Elem
                         {projectName}
                     </Title>
                 </Col>
-            </Row>
-            <Row justify='space-between' className='cvat-project-description'>
-                <Col>
-                    <Text type='secondary'>
-                        {`Project #${project.id} created`}
-                        {project.owner ? ` by ${project.owner.username}` : null}
-                        {` on ${moment(project.createdDate).format('MMMM Do YYYY')}`}
-                    </Text>
-                    <MdGuideControl instanceType='project' id={project.id} />
-                    <BugTrackerEditor
-                        instance={project}
-                        onChange={(bugTracker): void => {
-                            project.bugTracker = bugTracker;
-                            onUpdateProject(project);
-                        }}
-                    />
-                </Col>
                 <Col>
                     <Text type='secondary'>Assigned to</Text>
                     <UserSelector
                         value={project.assignee}
                         onSelect={(user) => {
                             project.assignee = user;
+                            onUpdateProject(project);
+                        }}
+                    />
+                </Col>
+            </Row>
+            <Row className='cvat-project-description'>
+                <Col span={24}>
+                    <Text type='secondary'>
+                        {`Project #${project.id} created`}
+                        {project.owner ? ` by ${project.owner.username}` : null}
+                        {` on ${moment(project.createdDate).format('MMMM Do YYYY')}`}
+                    </Text>
+                    <MdGuideControl instanceType='project' id={project.id} instance={project} />
+                    <BugTrackerEditor
+                        instance={project}
+                        onChange={(bugTracker): void => {
+                            project.bugTracker = bugTracker;
                             onUpdateProject(project);
                         }}
                     />

--- a/cvat-ui/src/components/project-page/styles.scss
+++ b/cvat-ui/src/components/project-page/styles.scss
@@ -54,7 +54,7 @@
         margin-bottom: $grid-unit-size * 2;
     }
 
-    .ant-row:nth-child(2) .ant-col:nth-child(2) > span {
+    .ant-row:nth-child(1) .ant-col:nth-child(2) > span {
         margin-right: $grid-unit-size;
     }
 

--- a/cvat-ui/src/components/task-page/details.tsx
+++ b/cvat-ui/src/components/task-page/details.tsx
@@ -226,7 +226,7 @@ class DetailsComponent extends React.PureComponent<Props, State> {
                     </Col>
                     <Col md={16} lg={17} xl={17} xxl={18}>
                         {this.renderDescription()}
-                        { taskInstance.projectId === null && <MdGuideControl instanceType='task' id={taskInstance.id} /> }
+                        { taskInstance.projectId === null && <MdGuideControl instanceType='task' id={taskInstance.id} instance={taskInstance} /> }
                         <Row justify='space-between' align='middle'>
                             <Col span={12}>
                                 <BugTrackerEditor


### PR DESCRIPTION
1. Fix not showing project description
2. Fix submitting project description not redirecting user back to project page
3. Improve project page layout to support showing project descriptions (potentially long and rich contents)

<img width="1848" height="840" alt="image" src="https://github.com/user-attachments/assets/73307ac6-703f-4768-85f2-5612d4be99ca" />
