### PR TITLE
CA-334: set default workspace to Review  for acceptance job stage 

### DIFF
--- a/cvat-ui/src/components/jobs-page/jobs-page.tsx
+++ b/cvat-ui/src/components/jobs-page/jobs-page.tsx
@@ -96,6 +96,7 @@ function JobsPageComponent(): JSX.Element {
                         getJobsAsync({
                             ...query,
                             filter,
+                            search: null,
                             page: 1,
                         }),
                     );

--- a/cvat-ui/src/components/jobs-page/top-bar.tsx
+++ b/cvat-ui/src/components/jobs-page/top-bar.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Col, Row } from 'antd/lib/grid';
 import Input from 'antd/lib/input';
 
@@ -29,6 +29,11 @@ function TopBarComponent(props: Props): JSX.Element {
         query, onApplyFilter, onApplySorting, onApplySearch,
     } = props;
     const [visibility, setVisibility] = useState(defaultVisibility);
+    const [searchValue, setSearchValue] = useState(query.search || '');
+
+    useEffect(() => {
+        setSearchValue(query.search || '');
+    }, [query.search]);
 
     return (
         <Row className='cvat-jobs-page-top-bar' justify='center' align='middle'>
@@ -36,12 +41,15 @@ function TopBarComponent(props: Props): JSX.Element {
                 <div>
                     <Input.Search
                         enterButton
+                        allowClear
+                        disabled={!!query.filter}
+                        value={searchValue}
+                        onChange={(e) => setSearchValue(e.target.value)}
                         onSearch={(phrase: string) => {
                             onApplySearch(phrase);
                         }}
-                        defaultValue={query.search || ''}
                         className='cvat-jobs-page-search-bar'
-                        placeholder='Search ...'
+                        placeholder={query.filter ? 'Clear filters to search' : 'Search ...'}
                     />
                     <div>
                         <SortingComponent

--- a/cvat-ui/src/reducers/annotation-reducer.ts
+++ b/cvat-ui/src/reducers/annotation-reducer.ts
@@ -199,7 +199,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
             } = action.payload;
 
             const defaultLabel = job.labels.length ? job.labels[0] : null;
-            const isReview = job.stage === JobStage.VALIDATION;
+            const isReview = job.stage === JobStage.VALIDATION || job.stage === JobStage.ACCEPTANCE;
             let workspaceSelected = null;
             let activeObjectType;
             let activeShapeType = null;


### PR DESCRIPTION
This PR:

1. Sets the default workspace mode to Review for jobs in 'acceptance' stage.
2. Fix a minor CVAT bug in Jobs searching and filtering. 
     - The bug: Job text search and job filters are mutually exclusive. When user enter a search text, he can not use the filtering and vice versa. The frontend is not resetting the job search status even when user clear the search text, stopping user from filtering.
     - The solution: 1. Automatically disable the text search when user starts filtering.  2. Adds a reset button icon to the search box so that user can manually unset the text search status.


<img width="1222" height="435" alt="image" src="https://github.com/user-attachments/assets/8d37f8f7-fcc4-4964-8654-75a68c4f204b" />


<img width="740" height="305" alt="image" src="https://github.com/user-attachments/assets/cd31b2a6-6df6-41d9-b447-0285e21b4388" />


---


<img width="1018" height="67" alt="image" src="https://github.com/user-attachments/assets/c19d5b86-497c-449c-bb4a-df4707fda7f6" />

